### PR TITLE
Fix prediction/annotation layer issues

### DIFF
--- a/src/napari_feature_classifier/annotator_widget.py
+++ b/src/napari_feature_classifier/annotator_widget.py
@@ -136,16 +136,7 @@ class LabelAnnotator(Container):
         for layer in self._viewer.layers:
             if type(layer) == napari.layers.Labels and layer.name == "Annotations":
                 self._viewer.layers.remove(layer)
-        self._annotations_layer = self._viewer.add_labels(
-            self._last_selected_label_layer.data,
-            scale=self._last_selected_label_layer.scale,
-            name="Annotations",
-            translate=self._last_selected_label_layer.translate,
-        )
-        self._annotations_layer.editable = False
-
-        # Set the label selection to a valid label layer => Running into proxy bug
-        self._viewer.layers.selection.active = self._last_selected_label_layer
+        self.add_annotations_layer()
 
         # Class selection
         self.ClassSelection = ClassSelection  # pylint: disable=C0103
@@ -212,11 +203,26 @@ class LabelAnnotator(Container):
             self._save_destination.enabled = False
             self._class_selector.enabled = False
 
+    def add_annotations_layer(self):
+        self._annotations_layer = self._viewer.add_labels(
+            self._last_selected_label_layer.data,
+            scale=self._last_selected_label_layer.scale,
+            name="Annotations",
+            translate=self._last_selected_label_layer.translate,
+        )
+        self._annotations_layer.editable = False
+        # Set the label selection to a valid label layer
+        self._viewer.layers.selection.active = self._last_selected_label_layer
+
     def toggle_label(self, labels_layer, event):
         """
         Callback for when a label is clicked. It then updates the color of that
         label in the annotation layer.
         """
+        # If the annotations layer is missing, add it back
+        if "Annotations" not in [x.name for x in self._viewer.layers]:
+            self.add_annotations_layer()
+
         # Need to translate & scale position that event.position returns by the
         # label_layer scale.
         # If scale is (1, 1, 1), nothing changes

--- a/src/napari_feature_classifier/classifier_widget.py
+++ b/src/napari_feature_classifier/classifier_widget.py
@@ -223,6 +223,7 @@ class ClassifierRunContainer(Container):
         self._last_selected_label_layer = get_selected_or_valid_label_layer(
             viewer=self._viewer
         )
+
         # Initialize the classifier
         if classifier:
             self._classifier = classifier
@@ -659,12 +660,19 @@ class LoadClassifierContainer(Container):
         with open(clf_path, "rb") as f:  # pylint: disable=C0103
             clf = pickle.load(f)
 
-        self._run_container = ClassifierRunContainer(
-            self._viewer,
-            clf,
-            classifier_save_path=clf_path,
-            auto_save=True,
-        )
+        try:
+            self._run_container = ClassifierRunContainer(
+                self._viewer,
+                clf,
+                classifier_save_path=clf_path,
+                auto_save=True,
+            )
+        except NotImplementedError:
+            napari_info(
+                "Create a label layer with a feature dataframe before loading "
+                "the classifier"
+            )
+            return
         self.clear()
         self.append(self._run_container)
 

--- a/src/napari_feature_classifier/classifier_widget.py
+++ b/src/napari_feature_classifier/classifier_widget.py
@@ -251,13 +251,7 @@ class ClassifierRunContainer(Container):
         for layer in self._viewer.layers:
             if type(layer) == napari.layers.Labels and layer.name == "Predictions":
                 self._viewer.layers.remove(layer)
-        self._prediction_layer = self._viewer.add_labels(
-            self._last_selected_label_layer.data,
-            scale=self._last_selected_label_layer.scale,
-            name="Predictions",
-            translate=self._last_selected_label_layer.translate,
-        )
-        self._prediction_layer.contour = 2
+        self.add_prediction_layer()
 
         # Set the label selection to a valid label layer => Running into proxy bug
         self._viewer.layers.selection.active = self._last_selected_label_layer
@@ -342,6 +336,15 @@ class ClassifierRunContainer(Container):
                     # using the layer name as roi_id
                     dict_of_features[layer.name] = layer.features
         self._classifier.add_dict_of_features(dict_of_features)
+
+    def add_prediction_layer(self):
+        self._prediction_layer = self._viewer.add_labels(
+            self._last_selected_label_layer.data,
+            scale=self._last_selected_label_layer.scale,
+            name="Predictions",
+            translate=self._last_selected_label_layer.translate,
+        )
+        self._prediction_layer.contour = 2
 
     def make_predictions(self):
         """
@@ -446,12 +449,7 @@ class ClassifierRunContainer(Container):
             "Predictions" not in [x.name for x in self._viewer.layers]
             and ensure_layer_presence
         ):
-            self._prediction_layer = self._viewer.add_labels(
-                self._last_selected_label_layer.data,
-                scale=self._last_selected_label_layer.scale,
-                name="Predictions",
-                translate=self._last_selected_label_layer.translate,
-            )
+            self.add_prediction_layer()
         if ensure_layer_presence:
             # Ensure correct layer order: This sometimes fails with weird
             # EmitLoopError & IndexError that should be ignored


### PR DESCRIPTION
Fix issues related to users removing annotation/prediction layers, ensuring annotation & prediction layers are on top when new layers get added and showing relevant help messages when a user tries to load a classifier without having opened a label layer.

Closes #51 