### PR TITLE
dependency cleanup; fixes #45 & #48

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,13 +36,15 @@ package_dir =
 
 # add your package requirements here
 install_requires =
-    numpy < 2.0
+    # numpy > 2.0
+    numpy 
     napari
     matplotlib
     magicgui
-    pandas
+    # pandas>=2.2.0 # for numpy > 2.0 support
+    pandas # for numpy > 2.0 support
     scikit-learn >= 1.2.2
-    pandera < 0.20.0
+    pandera 
     xxhash
     hypothesis
 

--- a/src/napari_feature_classifier/feature_loader_widget.py
+++ b/src/napari_feature_classifier/feature_loader_widget.py
@@ -15,8 +15,9 @@ from pathlib import Path
 
 from napari_feature_classifier.utils import napari_info
 
-
-class LabelFeatureSchema(pa.SchemaModel):
+# pandera.SchemaModel is now deprecated 
+# see https://github.com/unionai-oss/pandera/releases/tag/v0.20.0
+class LabelFeatureSchema(pa.DataFrameModel):
     # roi_id: Series[str] = pa.Field(coerce=True, unique=False)
     label: Series[int] = pa.Field(coerce=True, unique=True)
 


### PR DESCRIPTION
This PR fixes a few dependency issues, tests now pass without errors

1. pandera.SchemaModel was deprecated and I replaced it with pandera.DataFrameModel (see https://github.com/unionai-oss/pandera/releases/tag/v0.20.0)
https://github.com/fractal-napari-plugins-collection/napari-feature-classifier/blob/0814138307cb70fadad9bb83573d641824a1dd80/src/napari_feature_classifier/feature_loader_widget.py#L19
--> this fixed #45 ; Pandera does not have to be pinned to version < 0.20.0 (but I also didn't pin it to a specific version to make it robust as you mentioned in the issue)
2. #48 now supports numpy > 2.0

:) 